### PR TITLE
Cursor defaults to center of screen

### DIFF
--- a/TPEventsController.h
+++ b/TPEventsController.h
@@ -43,6 +43,7 @@
 - (void)stopPostingEvents;
 - (void)postEventWithEventData:(NSData*)eventData;
 
+- (void)warpMouseToCenter;
 - (void)warpMouseToPosition:(NSPoint)position;
 - (void)mouseDownAtPosition:(NSPoint)position;
 - (void)mouseUpAtPosition:(NSPoint)position;

--- a/TPEventsController.m
+++ b/TPEventsController.m
@@ -150,6 +150,15 @@
 	// overloaded
 }
 
+- (void)warpMouseToCenter
+{
+	NSArray * screens = [[TPLocalHost localHost] screens];
+	NSRect mainScreenRect = [screens[0] frame];
+
+	NSPoint centerPoint = NSMakePoint(NSMidX(mainScreenRect), NSMidY(mainScreenRect));
+	return [self warpMouseToPosition:centerPoint];
+}
+
 - (void)warpMouseToPosition:(NSPoint)position
 {
 	_currentMouseLocation = *(CGPoint*)&position;

--- a/TPServerController.m
+++ b/TPServerController.m
@@ -303,7 +303,7 @@ static TPServerController * _defaultServerController = nil;
 		_state = TPServerSharedState;
 		
 		if([[TPPreferencesManager sharedPreferencesManager] boolForPref:WRAP_ON_STOP_CONTROL])
-			[[self eventsController] warpMouseToPosition:NSMakePoint(16.0, 16.0)];
+			[[self eventsController] warpMouseToCenter];
 		
 		[[self eventsController] stopPostingEvents];
 		


### PR DESCRIPTION
Currently when you leave a remote screen, the cursor defaults near the top-left corner. This moves the cursor over the controls for YouTube when the video is in full-screen (see screenshot). This prevents the controls from fading away (which normally happens for fullscreen video).
![screenshot](https://cloud.githubusercontent.com/assets/1034157/17645811/ffc32ca8-617d-11e6-9a7f-481fd0361ecf.png)
