### PR TITLE
Bump version to 1.2.3

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>tlpt</string>
 	<key>CFBundleVersion</key>
-	<string>1.2.2</string>
+	<string>1.2.3</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
Update version string to release with updated Sparkle framework and enable builds for `arm64`.